### PR TITLE
Small fixes for error conditions

### DIFF
--- a/juniper-vpn.py
+++ b/juniper-vpn.py
@@ -23,6 +23,7 @@ import socket
 import netifaces
 import datetime
 import re
+import errno
 
 debug = False
 
@@ -303,6 +304,7 @@ class juniper_vpn(object):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 print >> sys.stderr, 'binary %s not found' % action[0]
+            raise
         ret = self.cprocess.returncode
 
         # Openconnect specific


### PR DESCRIPTION
If the script cannot find openconnect, it needed an import of the errno,
and also properply stop execution after the error.